### PR TITLE
Change to use ReadSB as default receiver

### DIFF
--- a/rootfs/etc/cont-init.d/50-vrs
+++ b/rootfs/etc/cont-init.d/50-vrs
@@ -86,6 +86,9 @@ cd "${VRS_DIR}"
 timeout $MAXTIME exec ${VRS_EXEC} ${VRS_CMDLINE[@]} >/dev/null 2>&1
 echo "[$APPNAME][$(date)] Virtual Radar Server has been initialized."
 
+# Replace 127.0.0.1 With ReadSB
+sed -i 's/<Address>127.0.0.1</Address>/<Address>readsb</Address>/g' "${VRS_CONFIG_DIR}/Configuration.xml"
+
 #Injecting settings for silhouettes, OpFlags and DB into Configuration.xml
 if ! grep -q "<DatabaseFileName>" "${VRS_CONFIG_DIR}/Configuration.xml"
  then


### PR DESCRIPTION
Since most people will be using ReadSB as they will be coming from the guide, without this change they need to manually edit the config file to get any data. 127.0.0.1 makes no sense in a container regardless