### PR TITLE
EXT_HFDLMARKERS_LINK repointed

### DIFF
--- a/rootfs/back/cont-init.d/60-marker
+++ b/rootfs/back/cont-init.d/60-marker
@@ -12,7 +12,7 @@ CCMARKER_ENABLED="%3cInjectSettings%3e%0a++++%3cInjectSettings%3e%0a++++++%3cEna
 
 #Downloadlinks
 EXT_MARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
-EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1HFDL.html"
+EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
 
 echo "[$APPNAME][$(date)] Starting CustomContent Markers script..."
 

--- a/rootfs/back/services.d/autoupdate/run
+++ b/rootfs/back/services.d/autoupdate/run
@@ -18,7 +18,7 @@ SILH_FILE="$VRS_CONFIG_DIR/silh"
 EXT_LOCALAC_LINK="https://raw.githubusercontent.com/rikgale/LocalAircraft/main/LocalAircraft.txt"
 #ExtraMarkers
 EXT_MARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
-EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1HFDL.html"
+EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
 
 #sqb update link
 FULLAIRCRAFT_LINK="https://github.com/rikgale/VRSData/raw/main/FullAircraft.zip"

--- a/rootfs/etc/s6-overlay/scripts/autoupdate
+++ b/rootfs/etc/s6-overlay/scripts/autoupdate
@@ -18,7 +18,7 @@ SILH_FILE="$VRS_CONFIG_DIR/silh"
 EXT_LOCALAC_LINK="https://raw.githubusercontent.com/rikgale/LocalAircraft/main/LocalAircraft.txt"
 #ExtraMarkers
 EXT_MARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
-EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1HFDL.html"
+EXT_HFDLMARKERS_LINK="https://raw.githubusercontent.com/rikgale/VRSCustomMarkers/main/MyMarkers1.html"
 
 #sqb update link
 FULLAIRCRAFT_LINK="https://github.com/rikgale/VRSData/raw/main/FullAircraft.zip"


### PR DESCRIPTION
As per previous  merge

Have merged the HFDL colours into the standard MyMarkers1.html file. Found a way to differentite between an HFDL a/c and a standard ADSB a/c. I now only have to maintain one script, rather than two.
Rather than try and undo everything in Update 60-marker script I just repointed EXT_MARKERSHFDL to the same location as EXT_MARKERS. This should not break current installs (hopefully).
Also updated the readme to reflect this, dropping reference to the hfdl option from the table of envars.