### PR TITLE
ci: remove the dead commented-out hadolint jobs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,21 +43,8 @@ jobs:
         run: |
           echo "Workflow dispatch reason: $INPUTS_REASON"
 
-  # hadolint:
-  #   name: Run hadolint against docker files
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v7.0.0
-  #       with:
-  #         ref: {{ env.GH_LABEL }}
-  #     - name: Pull hadolint/hadolint:latest Image
-  #       run: docker pull hadolint/hadolint:latest
-  #     - name: Run hadolint against Dockerfiles
-  #       run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   deploy_ghcr_multiarch:
     name: Deploy ghcr.io (Multi-Arch)
-    #   needs: [hadolint]
     runs-on: ubuntu-latest
     steps:
       # Check out our code

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -43,21 +43,8 @@ jobs:
         run: |
           echo "Workflow dispatch reason: $INPUTS_REASON"
 
-  # hadolint:
-  #   name: Run hadolint against docker files
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v7.0.0
-  #       with:
-  #         ref: {{ env.GH_LABEL }}
-  #     - name: Pull hadolint/hadolint:latest Image
-  #       run: docker pull hadolint/hadolint:latest
-  #     - name: Run hadolint against Dockerfiles
-  #       run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   deploy_ghcr_multiarch:
     name: Deploy ghcr.io (Multi-Arch)
-    # needs: [hadolint]
     runs-on: ubuntu-latest
     steps:
       # Check out our code

--- a/.github/workflows/deploy-v3p11.yml
+++ b/.github/workflows/deploy-v3p11.yml
@@ -47,21 +47,8 @@ jobs:
         run: |
           echo "Workflow dispatch reason: $INPUTS_REASON"
 
-  # hadolint:
-  #   name: Run hadolint against docker files
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v7.0.0
-  #       with:
-  #         ref: {{ env.GH_LABEL }}
-  #     - name: Pull hadolint/hadolint:latest Image
-  #       run: docker pull hadolint/hadolint:latest
-  #     - name: Run hadolint against Dockerfiles
-  #       run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   deploy_ghcr_multiarch:
     name: Deploy ghcr.io (Multi-Arch)
-    # needs: [hadolint]
     runs-on: ubuntu-latest
     steps:
       # Check out our code


### PR DESCRIPTION
## Problem

All three deploy workflows carry a fully commented-out `hadolint` job, dead since **2026-02-27** (*"remove hadolint from deploy action for now"*) — over three years. No job gated on it either: the `needs: [hadolint]` references were commented out along with it.

This surfaced during a fleet-wide audit of unpinned linter jobs prompted by hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209), which extended `DL3025` to fire on `HEALTHCHECK ... CMD` in v2.15.0 and silently broke several sibling repos. These blocks reference the same floating `hadolint/hadolint:latest` tag, so they are a trap if ever uncommented.

## Changes

Removes the dead blocks and the commented `needs:` lines from `deploy-main.yml`, `deploy-dev.yml` and `deploy-v3p11.yml`. Nothing that executes changes.

Coverage is unaffected: `check_docker = true`, so `lint.yaml` lints the Dockerfile on every PR via pre-commit against a `flake.lock`-pinned hadolint rather than the floating tag these blocks referenced.

## Verification

All three workflows still parse, with jobs intact and no dangling `needs:`:

```console
$ yq '.jobs | keys' .github/workflows/deploy-main.yml     # and -dev, -v3p11
- workflow-dispatch
- deploy_ghcr_multiarch

dangling needs: none
```

No `hadolint` remnants remain anywhere under `.github/workflows/`.

- `nix develop -c pre-commit run --all-files`: green, including `check-github-workflows` (schema validation) and `hadolint`
- No Dockerfile changes, so no image can be affected
- No hooks bypassed; no `--no-verify`
